### PR TITLE
Fix “Search location” input obscuring Google Maps "Map / Satellite”

### DIFF
--- a/action_plugins/google_maps/styles.css
+++ b/action_plugins/google_maps/styles.css
@@ -31,7 +31,7 @@
 	position: absolute;
 	z-index: 5;
 	top: 12px;
-	left: 36px;
+	left: 200px;
 	background: white;
 	border: 1px solid #D9D9D9;
 	border-top: 1px solid silver;


### PR DESCRIPTION
At least in our Elvis / Assets system, the “Search location” text input box is drawn partially on top of the Google Maps “Map / Satellite” button:
![2020-08-26 searchbox before fix](https://user-images.githubusercontent.com/3024544/91302107-3fd91480-e7a6-11ea-9e91-03ed520e0d30.png)

Increasing its “left” CSS position fixes that for us:
![2020-08-26 searchbox after fix](https://user-images.githubusercontent.com/3024544/91302103-3cde2400-e7a6-11ea-9b22-8f9ee2e59dbb.png)